### PR TITLE
Workaround debug menu crash

### DIFF
--- a/src/main/java/net/vulkanmod/vulkan/SystemInfo.java
+++ b/src/main/java/net/vulkanmod/vulkan/SystemInfo.java
@@ -1,12 +1,21 @@
 package net.vulkanmod.vulkan;
 
+import net.vulkanmod.Initializer;
 import oshi.hardware.CentralProcessor;
 
 public class SystemInfo {
     public static final String cpuInfo;
 
     static {
-        CentralProcessor centralProcessor = new oshi.SystemInfo().getHardware().getProcessor();
-        cpuInfo = String.format("%s", centralProcessor.getProcessorIdentifier().getName()).replaceAll("\\s+", " ");
+        CentralProcessor centralProcessor = null;
+        // Opening F3 crashes the game on one specific platform, this hack fixes it
+        try {
+            centralProcessor = new oshi.SystemInfo().getHardware().getProcessor();
+        } catch (NoClassDefFoundError e){
+            Initializer.LOGGER.warn("Failed to initialize OSHI class, no cpu info will be available");
+        }
+        cpuInfo = centralProcessor != null ?
+                String.format("%s", centralProcessor.getProcessorIdentifier().getName()).replaceAll("\\s+", " ") :
+                "Unknown";
     }
 }


### PR DESCRIPTION
Return stub cpu info string if OSHI class fails to initialize. Nothing more.